### PR TITLE
Feature/flag extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ If you have any suggestion, don't mind opening an issue please!!
 ### **Technologies**
 Dependency free!
 
-
 ---
 ### **Setup**
 > Note: Deno must be installed in your local environment. Tested on version 1.17, if you spot a problem in other versions, please do not hesitate opening an issue
@@ -78,8 +77,13 @@ Here are the Deno's built in commands (you may also run ``dyarn help`` ).
 - ```--config=```: if you wan't to create a custom dyarn config file or put it in a custom directory and use it when running your custom scripts
 
 ---
+### *Flags*
+- ``-c=[value]``, ``--config=[value]``, ``--config [value]`` and  ``-c [value]``: Sets the custom used config file path. (Be aware that if the flag is used multiple times, only the last one will be considered/used). e.g.: ``dyarn run --config ../disq-code/deno.json``, ``dyarn run --config ./config.json``
+- ~~``--env [value]``, ```--env=[value]``~~ still not available 
+
+---
 ### *Configs file*
-As our objective is to make you life a little easier with Deno commands, adding a custom config file or adding more flags, well... wouldn't help a lot. So by default (you may if you wan't, change this with the: ``` --config={path} ``` flag after dyarn invoker) dyarn uses Deno recommended config file name (and later auto identifiable file by Deno): ```deno.json```. 
+As our objective is to make you life a little easier with Deno commands, adding a custom config file or adding more flags, well... wouldn't help a lot. (if no custom path is provided with the flags ``-c=``, ``--config=``, ``--config`` and  ``-c`` dyarn will search for it's default one ``deno.json``)
 > Note: If more than one config file path is provided, the last one provided will be the used one!
 
 All dyarn options should be passed inside the ```dyarnOptions``` keys inside the deno.json file. 

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,6 @@
 import { PermsCheck } from './src/perms/check.ts'
 import { cli  } from './src/cli/mod.ts'
+import { flagExtractor } from './src/utils/flag-extractor.ts'
 
 
 //TODO Add https://deno.land/std@0.97.0/fmt for better logging and colors :)
@@ -9,9 +10,7 @@ await (async function main() {
       console.error("[ERROR] You must provide at least one argument!")
       Deno.exit(1)
    }
-   
-   const args = Array.from(Deno.args).splice(1)
-   const script = Deno.args[0]
+
    try {   
 
       //* Checking if script has right permissions to run
@@ -21,6 +20,14 @@ await (async function main() {
       //TODO Add OS check
       //TODO Add version check and update recommendation
       //TODO add flags to object[] to make it easier to check/use flags
+      const flags = flagExtractor(Deno.args)
+      if(flags.err) {
+         console.error(`[ERROR]: ${flags.err}`)
+         Deno.exit(1)
+      }
+
+      const script = flags.cmd as string
+      const args = flags.flags
       
       //* Actually running user's app
       const cliStatus = await cli(script, args)

--- a/mod.ts
+++ b/mod.ts
@@ -19,7 +19,6 @@ await (async function main() {
 
       //TODO Add OS check
       //TODO Add version check and update recommendation
-      //TODO add flags to object[] to make it easier to check/use flags
       const flags = flagExtractor(Deno.args)
       if(flags.err) {
          console.error(`[ERROR]: ${flags.err}`)

--- a/src/cli/invoke-cfg-scripts.ts
+++ b/src/cli/invoke-cfg-scripts.ts
@@ -49,7 +49,7 @@ export const invokeCfgScripts: InvokeCfgScriptsOverload =
    try {
       await Deno.stat(runFile)
    } catch (err) {
-      console.log(`[ERROR] The provided/default config file path "${runFile}" was not found!`)
+      console.error(`[ERROR] The provided/default config file path "${runFile}" was not found!`)
       Deno.exit(1)
    }
    if(!(await Deno.stat(runFile)).isFile) return {

--- a/src/cli/invoke-cfg-scripts.ts
+++ b/src/cli/invoke-cfg-scripts.ts
@@ -1,16 +1,17 @@
+import type { FlagsArray } from '../utils/flag-extractor.ts'
 import { configFile, getScripts } from '../config-file/mod.ts'
 import type { RunOptions } from '../../types/deno-types.d.ts'
 import { defaultFile } from '../global-defs.ts'
 
 interface InvokeCfgScriptsOverload {
-   (script: string, args: string[]): Promise<{ success: boolean, cmdData?: RunOptions, hasScripts?: boolean, err_msg?: string }>
+   (script: string, flags: FlagsArray): Promise<{ success: boolean, cmdData?: RunOptions, hasScripts?: boolean, err_msg?: string }>
 }
 
 //* Get config file and check for config scripts
 export const invokeCfgScripts: InvokeCfgScriptsOverload = 
-   async (script: string, args: string[]) => {
+   async (script: string, flags: FlagsArray) => {
    //* Getting config 
-   const configs = await configFile(args)
+   const configs = await configFile(flags)
 
    if(configs.err) return {
       success: false,

--- a/src/cli/invoke-dyarn-cmd.ts
+++ b/src/cli/invoke-dyarn-cmd.ts
@@ -1,47 +1,5 @@
-import type { CommandFlags } from '../dyarn-internal/mod.ts'
+import { checkFlags } from '../dyarn-internal/flags-check.ts'
 import { commands } from '../dyarn-internal/mod.ts'
-
-function checkFlags(args: string[], flagsToCheck: CommandFlags): { success: boolean, err_msg?: string } {
-   //* Getting flags and removing cli agrs characters
-   const flags = args.filter(arg => arg.startsWith('--'))
-      .map(arg => arg.replace('--', '').replace('=', ''))
-   
-   //* Checking if flags are required
-   if(flagsToCheck.required && (!flags || flags.length < 1)) return {
-      success: false,
-      err_msg: `This command requires flags, use help command to discover more!`
-   }
-
-   const filteredMissingFlags: string[] = []
-   flagsToCheck.arr.map(flagObj => {
-      if(!flagObj.required && !flags.includes(flagObj.flag)) return
-      if(!flags.includes(flagObj.flag)) return flagObj.flag
-
-      if(flagObj.dependsOnFlag){
-         const missingFlagDeps = flagObj.dependsOnFlag.filter(flag => !flags.includes(flag))
-         if(missingFlagDeps) return missingFlagDeps
-      }
-      return
-   }).filter(flag => !!flag).forEach(missingFlag => Array.isArray(missingFlag) ? 
-      missingFlag.forEach(subMissingFlag => 
-         !filteredMissingFlags.includes(subMissingFlag) && 
-            filteredMissingFlags.push(subMissingFlag)) 
-      : !filteredMissingFlags.includes(missingFlag!) && filteredMissingFlags.push(missingFlag!))
-
-   if(!filteredMissingFlags || !filteredMissingFlags[0]) return {
-      success: true
-   } 
-   else return {
-      success: false,
-      err_msg: `The following flag${
-         filteredMissingFlags.length > 1 ? 's' : ''
-      }: "${
-         filteredMissingFlags.join('", "')
-      }"; ${
-         filteredMissingFlags.length > 1 ? 'are' : 'is'
-      } missing for this command!`
-   }
-}
 
 export const invokeDyarnCommands = async (script: string, args: string[]): Promise<{
    success: true

--- a/src/cli/invoke-dyarn-cmd.ts
+++ b/src/cli/invoke-dyarn-cmd.ts
@@ -1,7 +1,8 @@
+import type { FlagsArray } from '../utils/flag-extractor.ts'
 import { checkFlags } from '../dyarn-internal/flags-check.ts'
 import { commands } from '../dyarn-internal/mod.ts'
 
-export const invokeDyarnCommands = async (script: string, args: string[]): Promise<{
+export const invokeDyarnCommands = async (script: string, flags: FlagsArray): Promise<{
    success: true
 } | {
    success: false
@@ -16,7 +17,7 @@ export const invokeDyarnCommands = async (script: string, args: string[]): Promi
    }
 
    if(command.flags){
-      const { success, err_msg } = checkFlags(args, command.flags)
+      const { success, err_msg } = checkFlags(flags, command.flags)
 
       if(!success) return {
          success: false,
@@ -24,7 +25,7 @@ export const invokeDyarnCommands = async (script: string, args: string[]): Promi
       }
    }
 
-   const runCommand = await command.run(args)
+   const runCommand = await command.run(flags)
 
    if(runCommand.success) return runCommand
    else return {

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1,19 +1,21 @@
 //* Iterates though all dyarn/deno/config file commands
 //* and calls the respective invoker
 
+import type { FlagsArray } from '../utils/flag-extractor.ts'
+
 import { invokeDyarnCommands } from './invoke-dyarn-cmd.ts'
 import { invokeCfgScripts } from './invoke-cfg-scripts.ts'
 
 
 //TODO Add update command and dyarn own commands
-export async function cli(script: string, args: string[]): 
+export async function cli(script: string, flags: FlagsArray): 
    Promise<{ success: true } | { success: false, err: string }>
    {
    //TODO Add extended verbose option that prints all errors, all warnings, file paths, env vars, etc.
    //TODO and maybe select which of them to print --verbose=all,err,warn,paths,env
 
    //* Dyarn own commands
-   const dayrnInternal = await invokeDyarnCommands(script, args)
+   const dayrnInternal = await invokeDyarnCommands(script, flags)
    if(dayrnInternal.success) return {
       success: true
    }
@@ -23,11 +25,11 @@ export async function cli(script: string, args: string[]):
    }
 
    //*Checking for config file commands 
-   const cfgCmd = await invokeCfgScripts(script, args.slice(1))
+   const cfgCmd = await invokeCfgScripts(script, flags)
       
    if(!cfgCmd.success && cfgCmd.hasScripts === false) return {
       success: false,
-      err: `Neither any Dyarn built in commands nor any config file scripts with name "${args[0]}" were found!`
+      err: `Neither any Dyarn built in commands nor any config file scripts with name "${script}" were found!`
    }
    if(!cfgCmd.success) return {
       success: false,
@@ -42,7 +44,7 @@ export async function cli(script: string, args: string[]):
 
    if(!success) return {
       success: false,
-      err: `Command "${args[0]}" failed with code ${code} and signal ${signal}!!`
+      err: `Command "${script}" failed with code ${code} and signal ${signal}!!`
    }
 
    return { success: true }

--- a/src/config-file/get-path.ts
+++ b/src/config-file/get-path.ts
@@ -17,7 +17,9 @@ export const getConfigFilePath: GetConfigFile = (flags: FlagsArray) => {
 
    //* Checking if any of the args are the custom config path one and if not
    //* returning default
-   const customConfigFileP = flags.find(flag => flag.flagName === flagsConsts.configFileFlag)
+   const customConfigFileP = flags.reverse().find(flag => 
+      flag.flagName === flagsConsts.configFileFlag || 
+      flag.flagName === flagsConsts.configFileMiniFlag )
    if(!customConfigFileP) return { configPath: defaultConfigFile }
 
    //* Checking if is really a path string

--- a/src/config-file/mod.ts
+++ b/src/config-file/mod.ts
@@ -1,3 +1,5 @@
+import type { FlagsArray } from '../utils/flag-extractor.ts'
+
 //* Assembles all config file functions in one
 import { ConfigOptions } from "./config-types.d.ts";
 import { getConfigsFromFile } from "./get-configs.ts"
@@ -5,15 +7,15 @@ import { getConfigFilePath } from "./get-path.ts"
 import { configsCheck } from './config-check.ts'
 
 interface ConfigFileMainOverload {
-   (args: string[]): Promise<{ config?: ConfigOptions, err?: true, err_msg?: string }>
-   (args: string[]): Promise<{ config?: ConfigOptions }>
+   (flags: FlagsArray): Promise<{ config?: ConfigOptions, err?: true, err_msg?: string }>
+   (flags: FlagsArray): Promise<{ config?: ConfigOptions }>
 }
 
 //TODO Add config file caching inside a .dyarn folder per project
 
-export const configFile: ConfigFileMainOverload = async (args: string []) => {
+export const configFile: ConfigFileMainOverload = async (flags: FlagsArray) => {
    //* Looking for config file and it's commands
-   const configPathGet = getConfigFilePath(args)
+   const configPathGet = getConfigFilePath(flags)
    if(configPathGet.err) return {
       err: true,
       err_msg: configPathGet.err_msg,

--- a/src/config-file/mod.ts
+++ b/src/config-file/mod.ts
@@ -27,7 +27,7 @@ export const configFile: ConfigFileMainOverload = async (flags: FlagsArray) => {
    try {
       await Deno.stat(configPath)
    } catch (err) {
-      console.log(`[ERROR] The provided/default config file path "${configPath}" was not found!`)
+      console.error(`[ERROR] The provided/default config file path "${configPath}" was not found!`)
       Deno.exit(1)
    }
    if(!(await Deno.stat(configPath)).isFile) return {

--- a/src/dyarn-internal/flags-check.ts
+++ b/src/dyarn-internal/flags-check.ts
@@ -1,0 +1,43 @@
+import type { CommandFlags } from '../dyarn-internal/mod.ts'
+
+export function checkFlags(args: string[], flagsToCheck: CommandFlags): { success: boolean, err_msg?: string } {
+   //* Getting flags and removing cli agrs characters
+   const flags = args.filter(arg => arg.startsWith('--'))
+      .map(arg => arg.replace('--', '').replace('=', ''))
+   
+   //* Checking if flags are required
+   if(flagsToCheck.required && (!flags || flags.length < 1)) return {
+      success: false,
+      err_msg: `This command requires flags, use help command to discover more!`
+   }
+
+   const filteredMissingFlags: string[] = []
+   flagsToCheck.arr.map(flagObj => {
+      if(!flagObj.required && !flags.includes(flagObj.flag)) return
+      if(!flags.includes(flagObj.flag)) return flagObj.flag
+
+      if(flagObj.dependsOnFlag){
+         const missingFlagDeps = flagObj.dependsOnFlag.filter(flag => !flags.includes(flag))
+         if(missingFlagDeps) return missingFlagDeps
+      }
+      return
+   }).filter(flag => !!flag).forEach(missingFlag => Array.isArray(missingFlag) ? 
+      missingFlag.forEach(subMissingFlag => 
+         !filteredMissingFlags.includes(subMissingFlag) && 
+            filteredMissingFlags.push(subMissingFlag)) 
+      : !filteredMissingFlags.includes(missingFlag!) && filteredMissingFlags.push(missingFlag!))
+
+   if(!filteredMissingFlags || !filteredMissingFlags[0]) return {
+      success: true
+   } 
+   else return {
+      success: false,
+      err_msg: `The following flag${
+         filteredMissingFlags.length > 1 ? 's' : ''
+      }: "${
+         filteredMissingFlags.join('", "')
+      }"; ${
+         filteredMissingFlags.length > 1 ? 'are' : 'is'
+      } missing for this command!`
+   }
+}

--- a/src/dyarn-internal/mod.ts
+++ b/src/dyarn-internal/mod.ts
@@ -1,10 +1,11 @@
+import type { FlagsArray } from '../utils/flag-extractor.ts'
 import { help } from './help/help-cmd.ts'
 
 export interface Command {
    invoker: string,
    description?: string,
    flags?: CommandFlags
-   run: (args: string[] | undefined) => Promise<{ success: true } | { success: false, err: string }>,
+   run: (flag: FlagsArray) => Promise<{ success: true } | { success: false, err: string }>,
 }
 
 export interface  CommandFlags {

--- a/src/global-defs.ts
+++ b/src/global-defs.ts
@@ -2,6 +2,8 @@ export const dyarnConfigKey = "dyarnOptions"
 export const defaultFile = "mod.ts"
 export const defaultConfigFile = "deno.json"
 
+export { flags } from './values/flags.ts'
+
 export const configType = {
    "_mainFile": "string",
    "_{}scripts": { 

--- a/src/utils/flag-extractor.ts
+++ b/src/utils/flag-extractor.ts
@@ -1,9 +1,14 @@
+export interface Flags {
+   flagName: string
+   flagValue: string | boolean
+}
+export type FlagsArray = Flags[] | undefined
+
+export type CMD = string
+
 export function flagExtractor(denoArgs: string[]): {
-   flags: {
-      flagName: string;
-      flagValue: string | boolean;
-   }[] | undefined
-   cmd: string
+   flags: FlagsArray
+   cmd: CMD
    err: undefined
 } | {
    flags: undefined

--- a/src/utils/flag-extractor.ts
+++ b/src/utils/flag-extractor.ts
@@ -1,0 +1,80 @@
+export function flagExtractor(denoArgs: string[]): {
+   flags: {
+      flagName: string;
+      flagValue: string | boolean;
+   }[] | undefined
+   cmd: string
+   err: undefined
+} | {
+   flags: undefined
+   cmd: undefined
+   err: string
+} {
+   const cmd = denoArgs[0]
+   const args = Array.from(Deno.args).splice(1)
+
+   if(!args) return {
+      flags: undefined, 
+      cmd,
+      err: undefined
+   }
+
+   const argsMap = args.map((arg, i) => {
+      //* Filtering what is not a flag name in case it is separated property
+      if(!arg.match(/^(--|-)/)) return
+      
+      const flagName = arg.replace(/^(--|-)/, '').replace(/=.+$/, '').replace(/=/, '')
+      
+      const subSanitizedValue =  arg.replace(/^(--|-)[^\s]+=/, '')
+      let flagValue: string | boolean
+      try {
+         flagValue = JSON.parse(subSanitizedValue)
+      } catch {
+         //* In case of error, it's not a JSON nor boolean
+         flagValue = subSanitizedValue
+      }
+
+      const isSeparated = !arg.match(/=/)
+      const nextItem = args[i + 1]
+
+      if(isSeparated && (!nextItem || nextItem.match(/^(--|-)[^\s]+=/))) return {
+         flagName,
+         flagValue: true
+      }
+      else if(isSeparated) return {
+         flagName,
+         flagValue: nextItem
+      } 
+      else if(typeof flagValue === 'undefined') return {
+         err: `Flag "${flagName}" has no value defined after it's \`=\` separator!`
+      }
+      return {
+         flagName,
+         flagValue
+      }
+   }).filter(arg => !!arg) 
+   
+   if(!argsMap) return {
+      flags: undefined,
+      cmd,
+      err: undefined
+   }
+
+   const isThereError = argsMap.map(arg => arg!.err)
+      .filter(arg => !!arg)
+
+   if(isThereError.length > 0) return {
+      flags: undefined,
+      cmd: undefined,
+      err: `The following error${isThereError.length > 1 ? 's' : ''} ocurred while trying to extract args: \n\n - ${isThereError.join('\n - ')}`
+   }
+
+   return {
+      flags: argsMap as { 
+         flagName: string,
+         flagValue: string | boolean
+      }[],
+      cmd,
+      err: undefined
+   }
+}

--- a/src/values/flags.ts
+++ b/src/values/flags.ts
@@ -1,0 +1,3 @@
+export const flags = {
+   configFileFlag: "config",
+}

--- a/src/values/flags.ts
+++ b/src/values/flags.ts
@@ -1,3 +1,4 @@
 export const flags = {
    configFileFlag: "config",
+   configFileMiniFlag: "c",
 }


### PR DESCRIPTION
- Added flag extraction script for more versatility with flags returning them as objects
- New flag formats: 
     - single line e.g.: ``-c=config.json``
     - double line e.g: ``--config=config.json``
     - no separator (single and double line) e.g.: ``--config config.json`` or ``-c config.json``
- Adaptation in other modules to support new flag extractor return type

