### PR TITLE
Fix/date consistency

### DIFF
--- a/_test/config-file/caching/cache-creation.ts
+++ b/_test/config-file/caching/cache-creation.ts
@@ -69,7 +69,7 @@ describe({
                cache: testCase.config,
                configFileModDate: testCase.configFileStat.mtime?.toISOString(),
                configFilePath: testCase.configFilePath,
-               cacheDate: new Date().toISOString(),
+               cacheDate: testCase.cliInfo.currDate.toISOString(),
                cacheFilePath: testCase.cacheFilePath,
             }
             

--- a/_test/config-file/caching/get-cache.ts
+++ b/_test/config-file/caching/get-cache.ts
@@ -20,7 +20,7 @@ import {
 } from './tests-list.ts'
 
 describe({
-   name: 'VALIDITY',
+   name: 'GET CACHE',
    suite: configCacheSuite,
    
 }, async () => {

--- a/_test/config-file/caching/mod.ts
+++ b/_test/config-file/caching/mod.ts
@@ -1,4 +1,4 @@
 export * from './cache-vallidity.ts'
 export * from './caching-invaidation.ts'
 export * from './cache-creation.ts'
-export * from './cache-creation.ts'
+export * from './get-cache.ts'

--- a/_test/config-file/caching/tests-list.ts
+++ b/_test/config-file/caching/tests-list.ts
@@ -18,7 +18,7 @@ const unusedDenoStatVars = { blksize: 0, blocks: 0, dev: 0, gid: 0, ino: 0, mode
 export const testsValidityCheckCases: {
    testName: string
    configFilePath: string
-   cliInfo: Partial<CLIInfo>
+   cliInfo: CLIInfo
    expected: {
       success: boolean
       hasCache: boolean | undefined
@@ -38,6 +38,7 @@ export const testsValidityCheckCases: {
       configFilePath: './deno.json',
       cliInfo: {
          cwd: '.',
+         currDate: new Date()
       },
       denoMocks: {
          denoStat: [
@@ -81,6 +82,7 @@ export const testsValidityCheckCases: {
       configFilePath: './deno.json',
       cliInfo: {
          cwd: '.',
+         currDate: new Date()
       },
       denoMocks: {
          denoStat: [
@@ -124,6 +126,7 @@ export const testsValidityCheckCases: {
       configFilePath: './deno.json',
       cliInfo: {
          cwd: '.',
+         currDate: new Date()
       },
       denoMocks: {
          denoStat: [
@@ -167,6 +170,7 @@ export const testsValidityCheckCases: {
       configFilePath: './deno.json',
       cliInfo: {
          cwd: '.',
+         currDate: new Date()
       },
       denoMocks: {
          denoStat: [
@@ -233,7 +237,8 @@ export const testsCreateCacheCases: {
       cacheFilePath: cacheMockFilePath,
       cliInfo: {
          cwd: '.',
-      } as CLIInfo,
+         currDate: new Date()
+      },
       configFileStat: {
          isFile: true,
          isDirectory: false,
@@ -259,7 +264,8 @@ export const testsReadConfigFileCases: {
       testName: 'Cache get succeeds',
       cliInfo: {
          cwd: '.',
-      } as CLIInfo,
+         currDate: new Date()
+      },
       configExpected: denoJsonMock1,
       cacheFileContent: denoJsonCacheMock1,
       success: true,

--- a/mod.ts
+++ b/mod.ts
@@ -26,6 +26,7 @@ await (async function main() {
          cmd: flags.cmd as string,
          flags: flags.flags,
          cwd: Deno.cwd(),
+         currDate: new Date()
       }
 
 
@@ -38,7 +39,6 @@ await (async function main() {
 
       //TODO Add OS check
       //TODO Add version check and update recommendation
-      //TODO Pass current time as cli info to prevent Date inconsistency issues
       
       //* Actually running user's app
       const cliStatus = await cli(cliInfo)

--- a/src/config-file/config-cache.ts
+++ b/src/config-file/config-cache.ts
@@ -104,7 +104,7 @@ export async function createCache(config: ConfigOptions, configFileStat: Deno.Fi
       cache: config,
       configFileModDate: configFileStat.mtime?.toISOString(),
       configFilePath: configFilePath,
-      cacheDate: new Date().toISOString(),
+      cacheDate: cliInfo.currDate.toISOString(),
       cacheFilePath: filePath.toString(),
    }
 

--- a/types/cli.d.ts
+++ b/types/cli.d.ts
@@ -4,6 +4,7 @@ import type {
 } from '../src/utils/flag-extractor.ts'
 
 export interface CLIInfo {
+   currDate: Date
    flags?: FlagsArray
    cmd?: CMD
    cwd?: string


### PR DESCRIPTION
### Description
To prevent date inconsistency between different steps of dyarn process, this fix adds a ``currDate`` property to ``cliInfo`` object.

### Main changes
- Added ``currDate`` property to ``cliInfo`` that at dyarn startup is set to ``new Date()``
- Adaption of the new ``cliInfo.currDate`` property inside modules, including:
  - ``createCache`` function  

### 3Rd party fixes
- Small fix with ``getCache`` function test execution/export and naming