### PR TITLE
Feature/improved logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ We plan on maybe adding some more things that we miss from Node's packages manag
 If you have any suggestion, don't mind opening an issue please!!
 
 ---
-### **Technologies**
-Dependency free!
-
----
 ### **Setup**
 > Note: Deno must be installed in your local environment. Tested on version 1.17, if you spot a problem in other versions, please do not hesitate opening an issue
 
@@ -112,6 +108,12 @@ All dyarn options should be passed inside the ```dyarnOptions``` keys inside the
    - *optional:* ```appFlags```: you may sometimes define flags inside your own apps, so we added this where you can put them. As they are custom and should be read by your app, Dyarn passes them after passing your app path on the CLI, just as when running Deno command's directly in the CLI. Not required and have no influence neither on Deno nor Dyarn.
    - *optional:* ```env```: in case you need to define some env variables inside your app, you may define them here. This option is optional and has an object format with any key/value type:
       - ```[key: any]: any```
+
+---
+### *Uses*
+- From Deno's standard library:
+   - FMT colors: https://deno.land/std@0.130.0/fmt/colors.ts
+
 
 ---
 ### *Contributing*

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,1 @@
+export * from 'https://deno.land/std@0.130.0/fmt/colors.ts'

--- a/mod.ts
+++ b/mod.ts
@@ -9,8 +9,6 @@ import {
    bgLogError
 } from './src/cli/logging.ts'
 
-//TODO Add https://deno.land/std@0.97.0/fmt for better logging and colors :)
-
 await (async function main() {
    //* Checking if there is any flag
    if(!Deno.args || Deno.args.length === 0) {

--- a/mod.ts
+++ b/mod.ts
@@ -4,41 +4,50 @@ import { PermsCheck } from './src/perms/check.ts'
 import { cli  } from './src/cli/mod.ts'
 import { flagExtractor } from './src/utils/flag-extractor.ts'
 
+import { 
+   prefixLogError,
+   bgLogError
+} from './src/cli/logging.ts'
 
 //TODO Add https://deno.land/std@0.97.0/fmt for better logging and colors :)
 
 await (async function main() {
    //* Checking if there is any flag
    if(!Deno.args || Deno.args.length === 0) {
-      console.error("[ERROR] You must provide at least one argument!")
+      bgLogError("You must provide at least one argument!", {
+         verbose: true
+      } as CLIInfo)
       Deno.exit(1)
    }
+   
+   //* Extracting flags and command
+   const flags = flagExtractor(Deno.args)
+   if(flags.err) {
+      prefixLogError(`${flags.err}`, {
+         verbose: true
+      } as CLIInfo)
+      Deno.exit(1)
+   }
+   
+   //* Checking if user want's to see extended verbose info
+   const verboseOn = flags.flags
+      ?.find(flag => flag.flagName === 'verbose')?.flagValue as boolean ?? false
 
+   const cliInfo: CLIInfo = {
+      cmd: flags.cmd as string,
+      flags: flags.flags,
+      cwd: Deno.cwd(),
+      currDate: new Date(),
+      verbose: verboseOn
+   }
+   
    try {   
-      //* Extracting flags and command
-      const flags = flagExtractor(Deno.args)
-      if(flags.err) {
-         console.error(`[ERROR]: ${flags.err}`)
-         Deno.exit(1)
-      }
-      
-      //* Checking if user want's to see extended verbose info
-      const verboseOn = flags.flags!
-         .find(flag => flag.flagName === 'verbose')?.flagValue as boolean ?? false
-         
-      const cliInfo: CLIInfo = {
-         cmd: flags.cmd as string,
-         flags: flags.flags,
-         cwd: Deno.cwd(),
-         currDate: new Date(),
-         verbose: verboseOn
-      }
 
 
       //* Checking if script has right permissions to run
-      const permissions = await PermsCheck()
+      const permissions = await PermsCheck(cliInfo)
       if(!permissions.success) {
-         console.error(`[ERROR]: ${permissions.err}`)
+         prefixLogError(`${permissions.err}`, cliInfo)
          Deno.exit(1)
       }
 
@@ -49,14 +58,14 @@ await (async function main() {
       const cliStatus = await cli(cliInfo)
 
       if(!cliStatus.success) {
-         console.error(`[ERROR]: ${cliStatus.err}`)
+         prefixLogError(`${cliStatus.err}`, cliInfo)
          Deno.exit(1)
       }
    
       //* Voila, finished!
       Deno.exit(0)
    } catch(error) {
-      console.log(`[UNEXPECTED ERROR]:\n ${error}`)
+      prefixLogError(`[UNEXPECTED]\n ${error}`, cliInfo)
       Deno.exit(1)
    }
 })()

--- a/mod.ts
+++ b/mod.ts
@@ -21,12 +21,17 @@ await (async function main() {
          console.error(`[ERROR]: ${flags.err}`)
          Deno.exit(1)
       }
-
+      
+      //* Checking if user want's to see extended verbose info
+      const verboseOn = flags.flags!
+         .find(flag => flag.flagName === 'verbose')?.flagValue as boolean ?? false
+         
       const cliInfo: CLIInfo = {
          cmd: flags.cmd as string,
          flags: flags.flags,
          cwd: Deno.cwd(),
-         currDate: new Date()
+         currDate: new Date(),
+         verbose: verboseOn
       }
 
 

--- a/src/cli/invoke-cfg-scripts.ts
+++ b/src/cli/invoke-cfg-scripts.ts
@@ -49,8 +49,10 @@ export const invokeCfgScripts: InvokeCfgScriptsOverload =
    try {
       await Deno.stat(runFile)
    } catch (err) {
-      console.error(`[ERROR] The provided/default config file path "${runFile}" was not found!`)
-      Deno.exit(1)
+      return {
+         success: false,
+         err_msg: `[ERROR] The provided/default config file path "${runFile}" was not found!`
+      }
    }
    if(!(await Deno.stat(runFile)).isFile) return {
       success: false,

--- a/src/cli/invoke-dyarn-cmd.ts
+++ b/src/cli/invoke-dyarn-cmd.ts
@@ -25,7 +25,7 @@ export const invokeDyarnCommands = async (cliInfo: CLIInfo): Promise<{
       }
    }
 
-   const runCommand = await command.run(cliInfo.flags)
+   const runCommand = await command.run(cliInfo.flags, cliInfo)
 
    if(runCommand.success) return runCommand
    else return {

--- a/src/cli/logging.ts
+++ b/src/cli/logging.ts
@@ -50,7 +50,7 @@ const neutralColor: Rgb = {
    b: 255,
 }
 
-function colorString(isBg: boolean, color: Rgb, msg: string, cliInfo: CLIInfo): string {
+export function colorString(isBg: boolean, color: Rgb, msg: string, cliInfo: CLIInfo): string {
    if(cliInfo.flags?.find(flag => flag.flagName === 'no-color')?.flagValue) 
       return msg
 
@@ -58,7 +58,7 @@ function colorString(isBg: boolean, color: Rgb, msg: string, cliInfo: CLIInfo): 
    else return rgb24(msg, color)
 }
 
-function fontFormat(msg: string, options: Options): string {
+export function fontFormat(msg: string, options: Options): string {
    let result = msg
    if(options.italic) result = italic(result)
    if(options.bold) result = bold(result)

--- a/src/cli/logging.ts
+++ b/src/cli/logging.ts
@@ -70,9 +70,9 @@ function fontFormat(msg: string, options: Options): string {
 }
 
 //* Logging functions with background color 
-export function bgLogNorm(msg: string, cliInfo: CLIInfo, opts: Options, color?: Rgb): void {
+export function bgLogNorm(msg: string, cliInfo: CLIInfo, opts?: Options, color?: Rgb): void {
    const colorLog = colorString(true, color ?? neutralColor, msg, cliInfo)
-   const formatLog = fontFormat(colorLog, opts)
+   const formatLog = opts ? fontFormat(colorLog, opts) : colorLog
 
    Deno.stdout.writeSync(new TextEncoder().encode(formatLog))
    return
@@ -108,9 +108,9 @@ export function bgLogVerbose(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
 }
 
 //* Logging functions with text color
-export function logNorm(msg: string, cliInfo: CLIInfo, opts: Options, color?: Rgb): void {
+export function logNorm(msg: string, cliInfo: CLIInfo, opts?: Options, color?: Rgb): void {
    const colorLog = colorString(false, color ?? neutralColor, msg, cliInfo)
-   const formatLog = fontFormat(colorLog, opts)
+   const formatLog = opts ? fontFormat(colorLog, opts) : colorLog
 
    Deno.stdout.writeSync(new TextEncoder().encode(formatLog))
    return

--- a/src/cli/logging.ts
+++ b/src/cli/logging.ts
@@ -51,7 +51,7 @@ const neutralColor: Rgb = {
 }
 
 function colorString(isBg: boolean, color: Rgb, msg: string, cliInfo: CLIInfo): string {
-   if(cliInfo.flags!.find(flag => flag.flagName === 'no-color')?.flagValue) 
+   if(cliInfo.flags?.find(flag => flag.flagName === 'no-color')?.flagValue) 
       return msg
 
    if(isBg) return bgRgb24(msg, color)
@@ -81,7 +81,7 @@ export function bgLogNorm(msg: string, cliInfo: CLIInfo, opts: Options, color?: 
 export function bgLogSuccess(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
    const colorLog = colorString(true, color ?? successColor, msg, cliInfo)
 
-   Deno.stdout.writeSync(new TextEncoder().encode())
+   Deno.stdout.writeSync(new TextEncoder().encode(colorLog))
    return 
 }
 

--- a/src/cli/logging.ts
+++ b/src/cli/logging.ts
@@ -1,0 +1,179 @@
+import type { CLIInfo } from './../../types/cli.d.ts';
+import {
+   bgRgb24,
+   rgb24,
+   underline,
+   bold,
+   italic,
+   dim,
+   strikethrough
+} from '../../deps.ts'
+
+interface Rgb {
+   r: number
+   g: number
+   b: number
+}
+
+interface Options {
+   italic?: boolean
+   bold?: boolean
+   underline?: boolean
+   dim?: boolean
+   strikethrough?: boolean
+}
+
+//* Color constants
+const warnColor: Rgb = {
+   r: 255,
+   g: 167,
+   b: 89,
+}
+const verboseColor: Rgb = {
+   r: 0,
+   g: 191,
+   b: 255,
+}
+const successColor: Rgb = {
+   r: 136,
+   g: 255,
+   b: 125,
+}
+const errorColor: Rgb = {
+   r: 255,
+   g: 102,
+   b: 115,
+}
+const neutralColor: Rgb = {
+   r: 255,
+   g: 255,
+   b: 255,
+}
+
+function colorString(isBg: boolean, color: Rgb, msg: string, cliInfo: CLIInfo): string {
+   if(cliInfo.flags!.find(flag => flag.flagName === 'no-color')?.flagValue) 
+      return msg
+
+   if(isBg) return bgRgb24(msg, color)
+   else return rgb24(msg, color)
+}
+
+function fontFormat(msg: string, options: Options): string {
+   let result = msg
+   if(options.italic) result = italic(result)
+   if(options.bold) result = bold(result)
+   if(options.underline) result = underline(result)
+   if(options.dim) result = dim(result)
+   if(options.strikethrough) result = strikethrough(result)
+   
+   return result
+}
+
+//* Logging functions with background color 
+export function bgLogNorm(msg: string, cliInfo: CLIInfo, opts: Options, color?: Rgb): void {
+   const colorLog = colorString(true, color ?? neutralColor, msg, cliInfo)
+   const formatLog = fontFormat(colorLog, opts)
+
+   Deno.stdout.writeSync(new TextEncoder().encode(formatLog))
+   return
+}
+
+export function bgLogSuccess(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
+   const colorLog = colorString(true, color ?? successColor, msg, cliInfo)
+
+   Deno.stdout.writeSync(new TextEncoder().encode())
+   return 
+}
+
+export function bgLogWarn(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
+   const colorLog = colorString(true, color ?? warnColor, msg, cliInfo)
+   
+   Deno.stdout.writeSync(new TextEncoder().encode(colorLog))
+   return 
+}
+
+export function bgLogError(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
+   const colorLog = colorString(true, color ?? errorColor, msg, cliInfo)
+
+   Deno.stdout.writeSync(new TextEncoder().encode(colorLog))
+   return
+}
+
+export function bgLogVerbose(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
+   const colorLog = colorString(true, color ?? verboseColor, msg, cliInfo)
+
+   if(cliInfo.verbose) 
+      Deno.stdout.writeSync(new TextEncoder().encode(colorLog))
+   return
+}
+
+//* Logging functions with text color
+export function logNorm(msg: string, cliInfo: CLIInfo, opts: Options, color?: Rgb): void {
+   const colorLog = colorString(false, color ?? neutralColor, msg, cliInfo)
+   const formatLog = fontFormat(colorLog, opts)
+
+   Deno.stdout.writeSync(new TextEncoder().encode(formatLog))
+   return
+}
+
+export function logSuccess(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
+   const colorLog = colorString(false, color ?? successColor, msg, cliInfo)
+   
+   Deno.stdout.writeSync(new TextEncoder().encode(colorLog))
+   return 
+}
+
+export function logWarn(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
+   const colorLog = colorString(false, color ?? warnColor, msg, cliInfo)
+   
+   Deno.stdout.writeSync(new TextEncoder().encode(colorLog))
+   return 
+}
+
+export function logError(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
+   const colorLog = colorString(false, color ?? errorColor, msg, cliInfo)
+   
+   Deno.stdout.writeSync(new TextEncoder().encode(colorLog))
+   return 
+}
+
+export function logVerbose(msg: string, cliInfo: CLIInfo, color?: Rgb): void {
+   const colorLog = colorString(false, color ?? verboseColor, msg, cliInfo)
+
+   if(cliInfo.verbose) 
+      Deno.stdout.writeSync(new TextEncoder().encode(colorLog))
+   return
+}
+
+//* Log a message with colored prefix
+export function prefixLogSuccess(msg: string, cliInfo: CLIInfo): void {
+   const colorPrefix = colorString(false, successColor, '[SUCCESS]', cliInfo)
+
+   const composedMsg = `${colorPrefix} -> ${msg}`
+   Deno.stdout.writeSync(new TextEncoder().encode(composedMsg))
+   return
+}
+
+export function prefixLogWarn(msg: string, cliInfo: CLIInfo): void {
+   const colorPrefix = colorString(false, warnColor, '[WARN]', cliInfo)
+
+   const composedMsg = `${colorPrefix} -> ${msg}`
+   Deno.stdout.writeSync(new TextEncoder().encode(composedMsg))
+   return
+}
+
+export function prefixLogVerbose(msg: string, cliInfo: CLIInfo): void {
+   const colorPrefix = colorString(false, verboseColor, '[VERBOSE]', cliInfo)
+
+   const composedMsg = `${colorPrefix} -> ${msg}`
+   Deno.stdout.writeSync(new TextEncoder().encode(composedMsg))
+   return
+}
+
+export function prefixLogError(msg: string, cliInfo: CLIInfo): void {
+   const colorPrefix = colorString(false, errorColor, '[ERR]', cliInfo)
+
+   const composedMsg = `${colorPrefix} -> ${msg}`
+   Deno.stdout.writeSync(new TextEncoder().encode(composedMsg))
+   return
+}

--- a/src/dyarn-internal/help/help-cmd.ts
+++ b/src/dyarn-internal/help/help-cmd.ts
@@ -1,8 +1,14 @@
+import type { CLIInfo } from './../../../types/cli.d.ts'
+
 import { commandsNoHelp } from '../mod.ts'
 
-//TODO fix, wrong flag '-a' being used, should be: '-l' or '--list'
+import {
+   logNorm,
+   fontFormat,
+   colorString
+} from '../../cli/logging.ts'
 
-export const help = async (): Promise<{
+export const help = async (cliInfo: CLIInfo): Promise<{
    success: true
 } | {
    success: false,
@@ -16,14 +22,20 @@ export const help = async (): Promise<{
       dyarn [command] [flags]
 
    FULL HELP: ${commandsNoHelp.map(cmd => `
-   - Command: '${cmd.invoker}'
-      Description: ${cmd.description}
+   - \`${
+      colorString(false, {r: 143, g: 255, b: 249}, cmd.invoker, cliInfo)
+   }\`
+      ${cmd.description ? fontFormat(cmd.description, {italic: true}) : 'No description'}
       ${cmd.flags ? `Flags: ${cmd.flags.arr.map(flag => `
-         - '${flag.flag}' - ${flag.required ? 'required' : 'optional'}
-            ${flag.description ? `Description: ${flag.description}` : ''}`)}` 
+         - \`${flag.flag}\` - ${
+            fontFormat(flag.required ? 'required' : 'optional', {dim: true})
+            }
+            ${flag.description ? `Description: ${
+               fontFormat(flag.description, {italic: true})
+            }` : ''}`)}` 
       : ''}`)}
    `
 
-   await console.log(helpString)
+   await logNorm(helpString, cliInfo)
    return { success: true }
 }

--- a/src/dyarn-internal/mod.ts
+++ b/src/dyarn-internal/mod.ts
@@ -55,12 +55,12 @@ export const commandsNoHelp: Command[] = [
          required: false,
          arr: [
             {
-               flag: '--list',
+               flag: '--all',
                required: false,
                description: 'Prints the list of all available versions',
             },
             {
-               flag: '-l',
+               flag: '-a',
                required: false,
                description: 'Prints the list of all available versions',
             }

--- a/src/dyarn-internal/mod.ts
+++ b/src/dyarn-internal/mod.ts
@@ -1,3 +1,4 @@
+import type { CLIInfo } from './../../types/cli.d.ts'
 import type { FlagsArray } from '../utils/flag-extractor.ts'
 
 import { issuesUrl, dyarnProjectDirPath, configFileCacheFileName } from '../global-defs.ts'
@@ -6,6 +7,11 @@ import { issuesUrl, dyarnProjectDirPath, configFileCacheFileName } from '../glob
 import { help } from './help/help-cmd.ts'
 import { getVersion } from './version.ts'
 import { invalidateCache } from '../config-file/config-cache.ts'
+
+import {
+   logNorm,
+   prefixLogSuccess
+} from '../cli/logging.ts'
 
 export interface Command {
    invoker: string,
@@ -28,8 +34,10 @@ export const commandsNoHelp: Command[] = [
    {
       invoker: 'issues',
       description: 'Gives you the link to the issues page of the project',
-      run: async () => {
-         await console.log(`You may open an issues at: ${issuesUrl}!`)
+      run: async (_flags, cliInfo) => {
+         await logNorm(`You may open an issues at: ${issuesUrl}!`, cliInfo, {
+            italic: true,
+         })
          return { success: true }
       }
    },
@@ -46,7 +54,14 @@ export const commandsNoHelp: Command[] = [
             },
          ],
       },
-      run: async () => { await console.log('Unavailable'); return {success: true} }
+      run: async (_flags, cliInfo) => { 
+         await logNorm('Sorry this is still unavailable', cliInfo, undefined, {
+            r: 241,
+            g: 255,
+            b: 48,
+         })
+         return {success: true} 
+      }
    },
    {
       invoker: 'version',
@@ -66,14 +81,17 @@ export const commandsNoHelp: Command[] = [
             }
          ],
       },
-      run: async (flags) => { const versionRun = await getVersion(flags); return versionRun },
+      run: async (flags, cliInfo) => { 
+         const versionRun = await getVersion(flags, cliInfo) 
+         return versionRun 
+      },
    },
    {
-      invoker: 'invalidate-cfg-cache',
+      invoker: 'clean',
       description: 'Invalidates the config file cache',
-      run: async () => {
-         await console.log(`  Invalidating config file cache...`)
-         const cachePath = `${Deno.cwd()}/${dyarnProjectDirPath}/${configFileCacheFileName}`
+      run: async (_flags, cliInfo) => {
+         logNorm(`Invalidating config file cache...`, cliInfo)
+         const cachePath = `${cliInfo.cwd}/${dyarnProjectDirPath}/${configFileCacheFileName}`
          const invalidateCacheResult = await invalidateCache(cachePath)
          
          if(!invalidateCacheResult.success) return {
@@ -81,7 +99,7 @@ export const commandsNoHelp: Command[] = [
             err: `Error invalidating config file cache:\n ${invalidateCacheResult.err}`,
          }
 
-         console.log(`   Successfully invalidated config file cache!`)
+         prefixLogSuccess(`Successfully invalidated config file cache!`, cliInfo)
          return {
             success: true,
          }
@@ -93,7 +111,7 @@ export const commands: Command[] = [
    {
       invoker: "help",
       description: "Prints this help message",
-      run: () => help(),
+      run: (_flags, cliInfo) => help(cliInfo),
    },
    ...commandsNoHelp
 ]

--- a/src/dyarn-internal/mod.ts
+++ b/src/dyarn-internal/mod.ts
@@ -11,7 +11,7 @@ export interface Command {
    invoker: string,
    description?: string,
    flags?: CommandFlags
-   run: (flag: FlagsArray) => Promise<{ success: true } | { success: false, err: string }>,
+   run: (flag: FlagsArray, cliInfo: CLIInfo) => Promise<{ success: true } | { success: false, err: string }>,
 }
 
 export interface  CommandFlags {

--- a/src/dyarn-internal/version.ts
+++ b/src/dyarn-internal/version.ts
@@ -1,16 +1,28 @@
+import type { CLIInfo } from './../../types/cli.d.ts'
 import type { FlagsArray } from '../utils/flag-extractor.ts'
 
 import { flags as flagsConsts, ghAPIUrl, allVersionsUrl, version } from '../global-defs.ts'
 
+import {
+   logNorm,
+} from '../cli/logging.ts'
+
 //* Lists current version or all versions
 
-export async function getVersion(flags: FlagsArray): Promise<{ 
+export async function getVersion(flags: FlagsArray, cliInfo: CLIInfo): Promise<{ 
    success: true 
 } | { 
    success: false, 
    err: string 
 }> {
-   console.log(`\n Your current version of Dyarn is: ${version}`)
+   logNorm(`\n Your current version of Dyarn is: `, cliInfo)
+   logNorm(version, cliInfo, {
+      italic: true,
+   },{
+      r: 143,
+      g: 255,
+      b: 249,
+   })
 
    const flag = flagsConsts.versionCmd.listAll
    const miniFlag = flagsConsts.versionCmd.listAllMini
@@ -28,7 +40,17 @@ export async function getVersion(flags: FlagsArray): Promise<{
       }
       if(versionsFetch.status === 200) {
          const versions = await versionsFetch.json() as { name: string }[]
-         console.log(`\n And the following versions are available: \n - Most recent -> ${versions[0].name} \n\n - Older versions: \n\n    ${versions.slice(1).map(ver => ver.name).join(', ')}`)
+         logNorm(`\n Available versions of Dyarn: \n`, cliInfo)
+         versions.forEach((version, i) => {
+            logNorm(' - ', cliInfo) 
+            logNorm(`${version.name}${i === 0 ? ' - (Most recent)' : ''}\n`, cliInfo, {
+               italic: true,
+            }, i === 0 ? {
+               r: 143,
+               g: 255,
+               b: 249,
+            } : undefined)
+         })
       } else return {
          success: false,
          err: `Could not fetch versions from GitHub!`

--- a/src/perms/check.ts
+++ b/src/perms/check.ts
@@ -1,8 +1,13 @@
+import type { CLIInfo } from '../../types/cli.d.ts'
 //* Checking if script has right permissions to run
 
 import { neededPerms } from '../global-defs.ts'
 
-export async function PermsCheck(): Promise<{
+import { 
+   bgLogWarn,
+} from '../cli/logging.ts'
+
+export async function PermsCheck(cliInfo: CLIInfo): Promise<{
    success: true
    err: undefined
 } | {
@@ -14,8 +19,8 @@ export async function PermsCheck(): Promise<{
 
       if(permQuery.state === "granted") return
       
-      //TODO Add as optional with --verbose flag
-      //console.warn(`It is highly recommended that you grant read permission to the runner at installation time!`)
+      
+      bgLogWarn(`It is highly recommended that you grant read permission to the runner at installation time!`, cliInfo)
 
       const permReq = await Deno.permissions.request({ name: perm as any })
 

--- a/types/cli.d.ts
+++ b/types/cli.d.ts
@@ -9,4 +9,5 @@ export interface CLIInfo {
    cmd?: CMD
    cwd?: string
    env?: Record<any, any>
+   verbose?: boolean
 }


### PR DESCRIPTION
### Main changes
- Added colored cli text: ``error``, ``verbose``, ``warn``, ``success``, ``neutral``, ``custom`` (background, text-color and prefixes options)
- Added formated cli text: ``italic``, ``dim``, ``bold``, ``strikethrough``, ``underline``
- 

### New dep
- Deno std lib - version 0.130.0 -> fmt colors

### Fixes
- Fixed help message that logged ``-l`` and ``--list`` for ``versions`` command instead of ``-a`` and ``--all``